### PR TITLE
Add `mqtt:Caller` and `onComplete` support

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "xlibb"
 name = "mqtt"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["xlibb"]
 keywords = ["mqtt"]
 repository = "https://github.com/xlibb/module-mqtt"
@@ -12,8 +12,8 @@ distribution = "2201.6.0"
 [[platform.java11.dependency]]
 groupId = "io.xlibb"
 artifactId = "mqtt"
-version = "0.0.1"
-path = "../native/build/libs/mqtt-native-0.0.1-SNAPSHOT.jar"
+version = "0.1.0"
+path = "../native/build/libs/mqtt-native-0.1.0-SNAPSHOT.jar"
 
 # Azure dependencies
 [[platform.java11.dependency]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,6 +9,26 @@ distribution-version = "2201.6.0"
 
 [[package]]
 org = "ballerina"
+name = "crypto"
+version = "2.3.1"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
+name = "io"
+version = "1.4.1"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"}
+]
+
+[[package]]
+org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
@@ -16,11 +36,133 @@ modules = [
 ]
 
 [[package]]
+org = "ballerina"
+name = "lang.__internal"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.error"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.int"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.object"
+version = "0.0.0"
+scope = "testOnly"
+
+[[package]]
+org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.value"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "log"
+version = "2.7.1"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
+]
+
+[[package]]
+org = "ballerina"
+name = "observe"
+version = "1.0.7"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "test"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.error"}
+]
+modules = [
+	{org = "ballerina", packageName = "test", moduleName = "test"}
+]
+
+[[package]]
+org = "ballerina"
+name = "time"
+version = "2.2.5"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "uuid"
+version = "1.5.1"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "uuid", moduleName = "uuid"}
+]
+
+[[package]]
 org = "xlibb"
 name = "mqtt"
 version = "0.1.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "uuid"}
 ]
 modules = [
 	{org = "xlibb", packageName = "mqtt", moduleName = "mqtt"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -18,7 +18,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "mqtt"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -80,6 +80,52 @@ task commitTomlFiles {
     }
 }
 
+task startMqttServer() {
+    doLast {
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            def stdOut = new ByteArrayOutputStream()
+            exec {
+                commandLine 'sh', '-c', "docker ps --filter name=mqtt-test"
+                standardOutput = stdOut
+            }
+            if (!stdOut.toString().contains("mqtt-test")) {
+                println "Starting Mqtt server."
+                exec {
+                    commandLine 'sh', '-c', "docker-compose -f tests/resources/docker-compose.yaml up -d"
+                    standardOutput = stdOut
+                }
+                println stdOut.toString()
+                sleep(5 * 1000)
+            } else {
+                println "Mqtt server is already running."
+            }
+        }
+    }
+}
+
+task stopMqttServer() {
+    doLast {
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            def stdOut = new ByteArrayOutputStream()
+            exec {
+                commandLine 'sh', '-c', "docker ps --filter name=mqtt-test"
+                standardOutput = stdOut
+            }
+            if (stdOut.toString().contains("mqtt-test")) {
+                println "Stopping Mqtt server."
+                exec {
+                    commandLine 'sh', '-c', "docker-compose -f tests/resources/docker-compose.yaml rm -svf"
+                    standardOutput = stdOut
+                }
+                println stdOut.toString()
+                sleep(5 * 1000)
+            } else {
+                println "Mqtt server is not started."
+            }
+        }
+    }
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
@@ -100,6 +146,9 @@ publishing {
 }
 
 updateTomlFiles.dependsOn copyStdlibs
+
+test.dependsOn startMqttServer
+test.finalizedBy stopMqttServer
 
 build.dependsOn ":mqtt-native:build"
 build.dependsOn "generatePomFileForMavenPublication"

--- a/ballerina/caller.bal
+++ b/ballerina/caller.bal
@@ -1,0 +1,9 @@
+import ballerina/jballerina.java;
+
+public client isolated class Caller {
+
+    isolated remote function complete() returns Error? =
+    @java:Method {
+        'class: "io.xlibb.mqtt.caller.CallerActions"
+    } external;
+}

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -8,7 +8,7 @@ public isolated client class Listener {
 
     # Creates a new `mqtt:Listener`.
     #
-    public isolated function init(string serverUri, string clientId, string|string[] topics, *ClientConfiguration config) returns Error? {
+    public isolated function init(string serverUri, string clientId, string|string[] topics, *ListenerConfiguration config) returns Error? {
         if topics is string {
             self.topics = [topics];
         } else {
@@ -17,7 +17,7 @@ public isolated client class Listener {
         check self.externInit(serverUri, clientId, config);
     }
 
-    private isolated function externInit(string serverUri, string clientId, *ClientConfiguration config) returns Error? =
+    private isolated function externInit(string serverUri, string clientId, *ListenerConfiguration config) returns Error? =
     @java:Method {
         'class: "io.xlibb.mqtt.listener.ListenerActions"
     } external;

--- a/ballerina/tests/publish_subscribe_tests.bal
+++ b/ballerina/tests/publish_subscribe_tests.bal
@@ -1,0 +1,42 @@
+import ballerina/log;
+import ballerina/lang.runtime;
+import ballerina/test;
+import ballerina/uuid;
+
+string receivedMessage = "";
+
+service on new Listener("tcp://localhost:1883", uuid:createType1AsString(), "mqtt/test", {
+    connectionConfig: {
+        username: "ballerina",
+        password: "ballerinamqtt",
+        connectionTimeout: 100
+    }
+}) {
+    remote function onMessage(Message message) returns error? {
+        log:printInfo(check string:fromBytes(message.payload));
+        receivedMessage = check string:fromBytes(message.payload);
+    }
+
+    remote function onError(Error err) returns error? {
+        log:printError("Error occured ", err);
+    }
+
+    remote function onCompleted(DeliveryToken token) returns error? {
+        log:printInfo("Message delivered " + token.messageId.toString());
+        log:printInfo(check string:fromBytes(token.message.payload));
+    }
+}
+
+@test:Config {enable: true}
+function basicPublishSubscribeTest() returns error? {
+    Client 'client = check new ("tcp://localhost:1883", uuid:createType1AsString(), {
+        connectionConfig: {
+            username: "ballerina",
+            password: "ballerinamqtt",
+            connectionTimeout: 100
+        }
+    });
+    check 'client->publish("mqtt/test", {payload: "This is a test message".toBytes()});
+    runtime:sleep(1);
+    test:assertEquals(receivedMessage, "This is a test message");
+}

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -18,6 +18,11 @@ public type ClientConfiguration record {|
     ConnectionConfiguration connectionConfig?;
 |};
 
+public type ListenerConfiguration record {|
+    ConnectionConfiguration connectionConfig?;
+    boolean manualAcks = false;
+|};
+
 public type ConnectionConfiguration record {|
     string username?;
     string password?;
@@ -28,6 +33,13 @@ public type ConnectionConfiguration record {|
     boolean cleanSession?;
     string[] serverUris?;
     boolean automaticReconnect?;
+|};
+
+public type DeliveryToken record {|
+    Message message;
+    int[] grantedQos;
+    int messageId;
+    string[] topics;
 |};
 
 # The Mqtt service type.

--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,11 @@ subprojects {
 
     dependencies {
         /* Standard libraries */
-        ballerinaStdLibs "io.ballerina.stdlib:io-ballerina:${stdlibIoVersion}"
+        ballerinaStdLibs "io.ballerina.stdlib:time-ballerina:${stdlibTimeVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:log-ballerina:${stdlibLogVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:os-ballerina:${stdlibOsVersion}"
+        ballerinaStdLibs "io.ballerina.stdlib:uuid-ballerina:${stdlibUuidVersion}"
+        ballerinaStdLibs "io.ballerina.stdlib:crypto-ballerina:${stdlibCryptoVersion}"
+        ballerinaStdLibs "io.ballerina.stdlib:io-ballerina:${stdlibIoVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:observe-ballerina:${observeVersion}"
         ballerinaStdLibs "io.ballerina:observe-ballerina:${observeInternalVersion}"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.xlibb
-version=0.0.1-SNAPSHOT
+version=0.1.0-SNAPSHOT
 ballerinaLangVersion=2201.6.0
 
 checkstylePluginVersion=8.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,12 +16,15 @@ pahoMqttVersion=1.2.5
 #stdlib dependencies
 
 # Level 01
-stdlibIoVersion=1.3.1
+stdlibTimeVersion=2.2.5
+stdlibIoVersion=1.4.1
 
 # Level 02
-stdlibLogVersion=2.5.0
-stdlibOsVersion=1.5.0
+stdlibLogVersion=2.7.1
+stdlibCryptoVersion=2.3.1
 
-# Ballerinax Observer
-observeVersion=1.0.5
-observeInternalVersion=1.0.4
+# Level 03
+stdlibUuidVersion=1.5.1
+
+observeVersion=1.0.7
+observeInternalVersion=1.0.6

--- a/native/src/main/java/io/xlibb/mqtt/caller/CallerActions.java
+++ b/native/src/main/java/io/xlibb/mqtt/caller/CallerActions.java
@@ -1,0 +1,26 @@
+package io.xlibb.mqtt.caller;
+
+import io.ballerina.runtime.api.values.BObject;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+
+import static io.xlibb.mqtt.utils.MqttUtils.createMqttError;
+
+/**
+ * Class containing the external methods of the caller.
+ */
+public class CallerActions {
+
+    public static Object complete(BObject callerObject) {
+        IMqttClient subscriber = (IMqttClient) callerObject.getNativeData("subscriber");
+        int messageId = (int) callerObject.getNativeData("messageId");
+        int qos = (int) callerObject.getNativeData("qos");
+        try {
+            subscriber.messageArrivedComplete(messageId, qos);
+        } catch (MqttException e) {
+            return createMqttError(e);
+        }
+        return null;
+    }
+
+}

--- a/native/src/main/java/io/xlibb/mqtt/listener/MqttCallbackImpl.java
+++ b/native/src/main/java/io/xlibb/mqtt/listener/MqttCallbackImpl.java
@@ -5,6 +5,8 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.Runtime;
 import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.RemoteMethodType;
+import io.ballerina.runtime.api.types.ServiceType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
@@ -12,10 +14,14 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.xlibb.mqtt.utils.ModuleUtils;
 import io.xlibb.mqtt.utils.MqttUtils;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -28,32 +34,38 @@ public class MqttCallbackImpl implements MqttCallback {
 
     private final Runtime runtime;
     private final BObject service;
+    private final IMqttClient subscriber;
 
-    public MqttCallbackImpl(Runtime runtime, BObject service) {
+    public MqttCallbackImpl(Runtime runtime, BObject service, IMqttClient subscriber) {
         this.runtime = runtime;
         this.service = service;
+        this.subscriber = subscriber;
     }
 
     @Override
     public void connectionLost(Throwable cause) {
         BError mqttError = MqttUtils.createMqttError(cause);
-        StrandMetadata metadata = getStrandMetadata("onError");
-        CountDownLatch latch = new CountDownLatch(1);
-        runtime.invokeMethodAsyncSequentially(service, "onError", null, metadata,
-                new BServiceInvokeCallbackImpl(latch), null, PredefinedTypes.TYPE_ANY, mqttError, true);
-        try {
-            latch.await(100, TimeUnit.SECONDS);
-        } catch (InterruptedException exception) {
-            exception.printStackTrace();
-        }
+        invokeOnError(mqttError);
     }
 
     @Override
     public void messageArrived(String topic, MqttMessage message) {
-        BMap<BString, Object> bMqttMessage = getBMqttMessage(message);
-        StrandMetadata metadata = getStrandMetadata("onMessage");
+        invokeOnMessage(message);
+    }
+
+    @Override
+    public void deliveryComplete(IMqttDeliveryToken token) {
+        BMap<BString, Object> bMqttMessage;
+        try {
+            bMqttMessage = getMqttDeliveryToken(token);
+        } catch (MqttException e) {
+            BError bError = MqttUtils.createMqttError(e);
+            invokeOnError(bError);
+            return;
+        }
+        StrandMetadata metadata = getStrandMetadata("onComplete");
         CountDownLatch latch = new CountDownLatch(1);
-        runtime.invokeMethodAsyncSequentially(service, "onMessage", null, metadata,
+        runtime.invokeMethodAsyncSequentially(service, "onComplete", null, metadata,
                 new BServiceInvokeCallbackImpl(latch), null, PredefinedTypes.TYPE_ANY, bMqttMessage, true);
         try {
             latch.await(100, TimeUnit.SECONDS);
@@ -62,24 +74,77 @@ public class MqttCallbackImpl implements MqttCallback {
         }
     }
 
-    @Override
-    public void deliveryComplete(IMqttDeliveryToken token) {
+    private void invokeOnMessage(MqttMessage message) {
+        BMap<BString, Object> bMqttMessage = getBMqttMessage(message);
+        StrandMetadata metadata = getStrandMetadata("onMessage");
+        CountDownLatch latch = new CountDownLatch(1);
+        boolean callerExists = isCallerAvailable();
+        if (callerExists) {
+            BObject callerObject = ValueCreator.createObjectValue(getModule(), "Caller");
+            callerObject.addNativeData("subscriber", subscriber);
+            callerObject.addNativeData("messageId", message.getId());
+            callerObject.addNativeData("qos", message.getQos());
+            runtime.invokeMethodAsyncSequentially(service, "onMessage", null, metadata,
+                    new BServiceInvokeCallbackImpl(latch), null, PredefinedTypes.TYPE_ANY,
+                    bMqttMessage, true, callerObject, true);
+        } else {
+            runtime.invokeMethodAsyncSequentially(service, "onMessage", null, metadata,
+                    new BServiceInvokeCallbackImpl(latch), null, PredefinedTypes.TYPE_ANY, bMqttMessage, true);
+        }
+        try {
+            latch.await(100, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            exception.printStackTrace();
+        }
+    }
 
+    private boolean isCallerAvailable() {
+        Optional<RemoteMethodType> onMessageMethodType = getOnMessageMethodType();
+        return onMessageMethodType.isPresent() && onMessageMethodType.get().getType().getParameters().length == 2;
+    }
+
+    private Optional<RemoteMethodType> getOnMessageMethodType() {
+        RemoteMethodType[] methodTypes = ((ServiceType) service.getOriginalType()).getRemoteMethods();
+        for (RemoteMethodType methodType: methodTypes) {
+            if (methodType.getName().equals("onMessage")) {
+                return Optional.of(methodType);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private void invokeOnError(BError bError) {
+        StrandMetadata metadata = getStrandMetadata("onError");
+        CountDownLatch latch = new CountDownLatch(1);
+        runtime.invokeMethodAsyncSequentially(service, "onError", null, metadata,
+                new BServiceInvokeCallbackImpl(latch), null, PredefinedTypes.TYPE_ANY, bError, true);
+        try {
+            latch.await(100, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            exception.printStackTrace();
+        }
     }
 
     private BMap<BString, Object> getBMqttMessage(MqttMessage message) {
         BMap<BString, Object> bMessage = ValueCreator.createRecordValue(getModule(), "Message");
-        byte[] payload = message.getPayload();
-        int messageId = message.getId();
-        int qos = message.getQos();
-        boolean retained = message.isRetained();
-        boolean duplicate = message.isDuplicate();
-        bMessage.put(StringUtils.fromString("payload"), ValueCreator.createArrayValue(payload));
-        bMessage.put(StringUtils.fromString("messageId"), messageId);
-        bMessage.put(StringUtils.fromString("qos"), qos);
-        bMessage.put(StringUtils.fromString("retained"), retained);
-        bMessage.put(StringUtils.fromString("duplicate"), duplicate);
+        bMessage.put(StringUtils.fromString("payload"), ValueCreator.createArrayValue(message.getPayload()));
+        bMessage.put(StringUtils.fromString("messageId"), message.getId());
+        bMessage.put(StringUtils.fromString("qos"), message.getQos());
+        bMessage.put(StringUtils.fromString("retained"), message.isRetained());
+        bMessage.put(StringUtils.fromString("duplicate"), message.isDuplicate());
         return bMessage;
+    }
+
+    private BMap<BString, Object> getMqttDeliveryToken(IMqttDeliveryToken token) throws MqttException {
+        MqttMessage mqttMessage = token.getMessage();
+        BMap<BString, Object> bMessage = getBMqttMessage(mqttMessage);
+        BMap<BString, Object> bDeliveryToken = ValueCreator.createRecordValue(getModule(), "DeliveryToken");
+        bDeliveryToken.put(StringUtils.fromString("message"), bMessage);
+        long[] qosArray = Arrays.stream(token.getGrantedQos()).asLongStream().toArray();
+        bDeliveryToken.put(StringUtils.fromString("grantedQos"), ValueCreator.createArrayValue(qosArray));
+        bDeliveryToken.put(StringUtils.fromString("messageId"), token.getMessageId());
+        bDeliveryToken.put(StringUtils.fromString("topics"), StringUtils.fromStringArray(token.getTopics()));
+        return bDeliveryToken;
     }
 
     private StrandMetadata getStrandMetadata(String parentFunctionName) {

--- a/native/src/main/java/io/xlibb/mqtt/utils/MqttUtils.java
+++ b/native/src/main/java/io/xlibb/mqtt/utils/MqttUtils.java
@@ -15,9 +15,9 @@ import static io.xlibb.mqtt.utils.ModuleUtils.getModule;
  */
 public class MqttUtils {
 
-    public static MqttConnectOptions getMqttConnectOptions(BMap<BString, Object> clientConfiguration) {
+    public static MqttConnectOptions getMqttConnectOptions(BMap<BString, Object> configuration) {
         MqttConnectOptions options = new MqttConnectOptions();
-        Object connectionConfigObject = clientConfiguration.get(StringUtils.fromString("connectionConfig"));
+        Object connectionConfigObject = configuration.get(StringUtils.fromString("connectionConfig"));
         if (connectionConfigObject != null && connectionConfigObject instanceof BMap) {
             BMap<BString, Object> connectionConfig = (BMap<BString, Object>) connectionConfigObject;
             Object username = connectionConfig.get(StringUtils.fromString("username"));

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -1,6 +1,4 @@
 module io.ballerina.stdlib.kafka.runtime {
     requires io.ballerina.runtime;
     requires org.eclipse.paho.client.mqttv3;
-    exports io.xlibb.mqtt.client;
-
 }


### PR DESCRIPTION
## Purpose
$subject
Now the following is supported.
```bal
import xlibb/mqtt;
import ballerina/log;
import ballerina/uuid;

service on new mqtt:Listener("tcp://localhost:1883", uuid:createType1AsString(), "mqtt/test", {
    connectionConfig: {
        username: "ballerina",
        password: "ballerinamqtt",
        connectionTimeout: 100
    },
    manualAcks: false
}) {
    remote function onMessage(mqtt:Message message, mqtt:Caller caller) returns error? {
        log:printInfo(check string:fromBytes(message.payload));
        check caller->complete();
    }

    remote function onError(mqtt:Error err) returns error? {
        log:printError("Error occured ", err);
    }
    
    remote function onCompleted(mqtt:DeliveryToken token) returns error? {
        log:printInfo("Message delivered " + token.messageId.toString());
        log:printInfo(check string:fromBytes(token.message.payload));
    }
}

```
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
